### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     install_requires=[        
         'graphene-django>=2.0.dev',
         'Django>=1.8.0',
-        'django-filter==1.0.2',
+        'django-filter>=1.0.2',
         'djangorestframework>=3.6.3',
     ],    
     include_package_data=True,


### PR DESCRIPTION
Setup.py fixes on django-filter==1.0.2, but 1.0.4 also works.

If you have a newer version installed, it gets downgraded.