### PR TITLE
Update DRF compatibility

### DIFF
--- a/graphene_django_extras/converter.py
+++ b/graphene_django_extras/converter.py
@@ -12,10 +12,9 @@ from graphene.utils.str_converters import to_camel_case, to_const
 from graphene_django.compat import ArrayField, HStoreField, RangeField, JSONField
 from graphene_django.fields import DjangoListField
 from graphene_django.utils import import_single_dispatch
-from rest_framework.compat import get_related_model
 
 from .fields import DjangoFilterListField
-from .utils import is_required, get_model_fields
+from .utils import is_required, get_model_fields, get_related_model
 from .base_types import Date, GenericForeignKeyType, GenericForeignKeyInputType
 
 singledispatch = import_single_dispatch()

--- a/graphene_django_extras/utils.py
+++ b/graphene_django_extras/utils.py
@@ -11,6 +11,15 @@ from graphene_django.utils import is_valid_django_model, get_reverse_fields
 from graphql import GraphQLList, GraphQLNonNull
 from graphql.language.ast import FragmentSpread
 from six import string_types
+from rest_framework.compat import _resolve_model
+
+
+def get_related_model(field):
+    # Backward compatibility patch for Django versions lower than 1.9.x
+    # Function taken from DRF 3.6.x
+    if DJANGO_VERSION < (1, 9):
+        return _resolve_model(field.rel.to)
+    return field.remote_field.model
 
 
 def get_model_fields(model):

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         'graphene-django>=2.0.dev2017083101',
         'Django>=1.8.0',
         'django-filter>=1.0.4',
-        'djangorestframework~=3.6.0'
+        'djangorestframework>=3.6.0'
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Fix for #7 using [DRF 3.6 `get_related_model`](https://github.com/encode/django-rest-framework/blob/fed85bc29d7965749e86ee86c63d140f2e50e843/rest_framework/compat.py#L142)
```py
def get_related_model(field):
    if django.VERSION < (1, 9):
        return _resolve_model(field.rel.to)
    return field.remote_field.model
```
`_resolve_model` is still present on DRF 3.7