### PR TITLE
Pass info.context to filterset as request

### DIFF
--- a/graphene_django_extras/fields.py
+++ b/graphene_django_extras/fields.py
@@ -248,7 +248,7 @@ class DjangoListObjectField(Field):
 
         filter_kwargs = {k: v for k, v in kwargs.items() if k in filtering_args}
 
-        qs = filterset_class(data=filter_kwargs, queryset=qs).qs
+        qs = filterset_class(data=filter_kwargs, queryset=qs, request=info.context).qs
         count = qs.count()
 
         return DjangoListObjectBase(

--- a/graphene_django_extras/fields.py
+++ b/graphene_django_extras/fields.py
@@ -185,7 +185,7 @@ class DjangoFilterPaginateListField(Field):
 
         filter_kwargs = {k: v for k, v in kwargs.items() if k in filtering_args}
         qs = queryset_factory(manager, info.field_asts, info.fragments, **kwargs)
-        qs = filterset_class(data=filter_kwargs, queryset=qs).qs
+        qs = filterset_class(data=filter_kwargs, queryset=qs, request=info.context).qs
 
         if root and is_valid_django_model(root._meta.model):
             extra_filters = get_extra_filters(root, manager.model)


### PR DESCRIPTION
This update will pass info.context into the filterset_class for DjangoListObjectField and DjangoFilterPaginateListField and be available as self.request per the Django FilterSet convention. This should resolve issue #28 