### PR TITLE
Add logic to support ordering of queryset in LimitOffsetPagination.

### DIFF
--- a/graphene_django_extras/paginations/fields.py
+++ b/graphene_django_extras/paginations/fields.py
@@ -26,12 +26,14 @@ class LimitOffsetPaginationField(AbstractPaginationField):
 
     def __init__(self, _type, default_limit=graphql_api_settings.DEFAULT_PAGE_SIZE,
                  max_limit=graphql_api_settings.MAX_PAGE_SIZE,
-                 limit_query_param='limit', offset_query_param='offset', *args, **kwargs):
+                 limit_query_param='limit', offset_query_param='offset', order_query_param='order',
+                 *args, **kwargs):
 
         kwargs.setdefault('args', {})
 
         self.limit_query_param = limit_query_param
         self.offset_query_param = offset_query_param
+        self.order_query_param = order_query_para
         self.max_limit = max_limit
         self.default_limit = default_limit
         self.limit_query_description = 'Number of results to return per page. Actual \'default_limit\': {}, and ' \
@@ -43,6 +45,9 @@ class LimitOffsetPaginationField(AbstractPaginationField):
 
         kwargs[offset_query_param] = Int(default_value=0,
                                          description=self.offset_query_description)
+        
+        kwargs[order_query_param] = String(default_value='',
+                                           description=self.order_query_description)
 
         super(LimitOffsetPaginationField, self).__init__(List(_type), *args, **kwargs)
 
@@ -54,6 +59,10 @@ class LimitOffsetPaginationField(AbstractPaginationField):
             strict=True,
             cutoff=self.max_limit
         )
+
+        order = kwargs.pop(self.order_query_param, None)
+        if order:
+            qs = qs.order_by(order)
 
         if limit < 0:
             offset = kwargs.pop(self.offset_query_param, None) or count

--- a/graphene_django_extras/paginations/fields.py
+++ b/graphene_django_extras/paginations/fields.py
@@ -33,7 +33,7 @@ class LimitOffsetPaginationField(AbstractPaginationField):
 
         self.limit_query_param = limit_query_param
         self.offset_query_param = offset_query_param
-        self.order_query_param = order_query_para
+        self.order_query_param = order_query_param
         self.max_limit = max_limit
         self.default_limit = default_limit
         self.limit_query_description = 'Number of results to return per page. Actual \'default_limit\': {}, and ' \


### PR DESCRIPTION
Thanks for this super helpful library! This is just a quick update that should add an input field 'order' for use with the LimitOffsetPagination class. This input will be passed to the queryset.order_by() method to sort results before pagination and so uses the same syntax as the Django method, ie. order: "id" or order: "-id". 