### PR TITLE
Fix typo in README.* files

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ for DjangoListObjectType classes pagination definitions on settings.py like this
 ```python
 from django.contrib.auth.models import User
 from graphene_django_extras import DjangoListObjectType, DjangoSerializerType, DjangoObjectType
-from graphene_django_extras.pagination import LimitOffsetGraphqlPagination
+from graphene_django_extras.paginations import LimitOffsetGraphqlPagination
 
 from .serializers import UserSerializer
 
@@ -139,7 +139,7 @@ class UserSerializerMutation(DjangoSerializerMutation):
 class UserMutation(graphene.Mutation):
     """
          On traditional mutation classes definition you must implement the mutate function
-         
+
     """
 
     user = graphene.Field(UserType, required=False)

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ DjangoListObjectType classes pagination definitions on settings.py like this:
     from django.contrib.auth.models import User
     from graphene_django import DjangoObjectType
     from graphene_django_extras import DjangoListObjectType, DjangoSerializerType
-    from graphene_django_extras.pagination import LimitOffsetGraphqlPagination
+    from graphene_django_extras.paginations import LimitOffsetGraphqlPagination
 
     from .serializers import UserSerializer
 


### PR DESCRIPTION
Small typo in README files import fixed. (A few whitespaces improvement go for free)
¡Muchas gracias!