### PR TITLE
Imports _resolve_model (for Django<1.9) only when it actually is running in Django<1.9

### DIFF
--- a/graphene_django_extras/utils.py
+++ b/graphene_django_extras/utils.py
@@ -12,7 +12,6 @@ from graphene.utils.str_converters import to_snake_case
 from graphene_django.utils import is_valid_django_model, get_reverse_fields
 from graphql import GraphQLList, GraphQLNonNull
 from graphql.language.ast import FragmentSpread
-from rest_framework.compat import _resolve_model
 from six import string_types
 
 
@@ -25,6 +24,7 @@ def get_related_model(field):
     # Backward compatibility patch for Django versions lower than 1.9.x
     # Function taken from DRF 3.6.x
     if DJANGO_VERSION < (1, 9):
+        from rest_framework.compat import _resolve_model
         return _resolve_model(field.rel.to)
     return field.remote_field.model
 


### PR DESCRIPTION
Quick solution. :)