### PR TITLE
Added tests for Query's fields

### DIFF
--- a/graphene_django_extras/tests/queries.py
+++ b/graphene_django_extras/tests/queries.py
@@ -1,0 +1,34 @@
+ALL_USERS = '''query {
+  allUsers {
+    results {
+      id
+    }
+  }
+}
+'''
+ALL_USERS1 = '''query {
+  allUsers1 {
+      id
+  }
+}
+'''
+ALL_USERS2 = '''query {
+  allUsers2 {
+      id
+  }
+}
+'''
+ALL_USERS3 = '''query {
+  allUsers3 {
+      id
+  }
+}
+'''
+ALL_USERS3_WITH_FILTER = '''query {
+  allUsers3 (%(filter)s) {
+    results {
+      %(fields)s
+    }
+  }
+}
+'''

--- a/graphene_django_extras/tests/test_fields.py
+++ b/graphene_django_extras/tests/test_fields.py
@@ -1,24 +1,91 @@
 from django.test import TestCase
 from graphene_django_extras.tests.client import Client
 from graphene_django_extras.tests import factories
+from graphene_django_extras.tests import queries
 
 
-query = '''query {
-  allUsers {
-    results {
-      id
-    }
-  }
-}
-'''
 class DjangoListObjectFieldTest(TestCase):
-    def test_foo(self):
+    def test_field(self):
         user = factories.UserFactory()
         client = Client()
-        response = client.query(query)
+        response = client.query(queries.ALL_USERS)
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertIn('data', data)
         self.assertIn('allUsers', data['data'])
         self.assertIn('results', data['data']['allUsers'])
-        self.assertTrue(data['data']['allUsers'])
+        self.assertTrue(data['data']['allUsers']['results'])
+        self.assertEqual(data['data']['allUsers']['results'][0]['id'], str(user.id))
+
+
+class DjangoFilterPaginateListFieldTest(TestCase):
+    def test_field(self):
+        user = factories.UserFactory()
+        client = Client()
+        response = client.query(queries.ALL_USERS1)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn('data', data)
+        self.assertIn('allUsers1', data['data'])
+        self.assertIn('results', data['data']['allUsers1'])
+        self.assertTrue(data['data']['allUsers1'])
+        self.assertEqual(data['data']['allUsers1'][0]['id'], str(user.id))
+
+
+class DjangoFilterListFieldTest(TestCase):
+    def test_field(self):
+        user = factories.UserFactory()
+        client = Client()
+        response = client.query(queries.ALL_USERS2)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn('allUsers2', data['data'])
+        self.assertTrue(data['data']['allUsers2'])
+        self.assertEqual(data['data']['allUsers2'][0]['id'], str(user.id))
+
+
+class DjangoListObjectFieldWithFiltersetTest(TestCase):
+    def test_filter_id(self):
+        user = factories.UserFactory()
+        query = queries.ALL_USERS3_WITH_FILTER % {
+            'filter': 'id: %s' % user.id,
+            'fields': 'username',
+        }
+        client = Client()
+        response = client.query(query)
+        self.assertEqual(response.status_code, 200, response.content)
+        data = response.json()
+        self.assertIn('allUsers3', data['data'])
+        self.assertIn('results', data['data']['allUsers3'])
+        self.assertTrue(data['data']['allUsers3']['results'])
+        self.assertEqual(data['data']['allUsers3']['results'][0]['username'], user.username)
+
+    def test_filter_charfield_icontains(self):
+        user = factories.UserFactory()
+        query = queries.ALL_USERS3_WITH_FILTER % {
+            'filter': 'email_Icontains: "%s"' % user.email.split('@')[0],
+            'fields': 'username',
+        }
+        client = Client()
+        response = client.query(query)
+        self.assertEqual(response.status_code, 200, response.content)
+        data = response.json()
+        self.assertIn('allUsers3', data['data'])
+        self.assertIn('results', data['data']['allUsers3'])
+        self.assertTrue(data['data']['allUsers3']['results'])
+        self.assertEqual(data['data']['allUsers3']['results'][0]['username'], user.username)
+
+    def test_filter_charfield_iexact(self):
+        user = factories.UserFactory()
+        query = queries.ALL_USERS3_WITH_FILTER % {
+            'filter': 'email_Iexact: "%s"' % user.email,
+            'fields': 'username',
+        }
+        client = Client()
+        response = client.query(query)
+        self.assertEqual(response.status_code, 200, response.content)
+        data = response.json()
+        self.assertIn('allUsers3', data['data'])
+        self.assertIn('results', data['data']['allUsers3'])
+        self.assertTrue(data['data']['allUsers3']['results'])
+        self.assertEqual(data['data']['allUsers3']['results'][0]['username'], user.username)

--- a/testproject/filtersets.py
+++ b/testproject/filtersets.py
@@ -5,4 +5,11 @@ import django_filters as filters
 class UserFilter(filters.FilterSet):
     class Meta:
         model = auth_models.User
-        fields = '__all__'
+        fields = {
+            'id': ['exact', ],
+            'first_name': ['icontains', 'iexact'],
+            'last_name': ['icontains', 'iexact'],
+            'username': ['icontains', 'iexact'],
+            'email': ['icontains', 'iexact'],
+            'is_staff': ['exact']
+        }


### PR DESCRIPTION
There's a failing tests : 
```
======================================================================
ERROR: test_field (graphene_django_extras.tests.test_fields.DjangoFilterPaginateListFieldTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/zulu/projects/graphene-django-extras/graphene_django_extras/tests/test_fields.py", line 30, in test_field
    self.assertIn('results', data['data']['allUsers1'])
  File "/usr/lib/python3.5/unittest/case.py", line 1076, in assertIn
    if member not in container:
TypeError: argument of type 'NoneType' is not iterable

----------------------------------------------------------------------
```

Do you have an idea why ?