### PR TITLE
pin version of django-filter package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
 
     install_requires=[
         'graphene-django>=2.0',
-        'django-filter>=1.0.4',
+        'django-filter<2',
         'djangorestframework>=3.6.0'
     ],
     extras_require={


### PR DESCRIPTION
The _django-filter_ package version should be pinned

Until this gets fixed: https://github.com/graphql-python/graphene-django/issues/464

As in here: https://github.com/graphql-python/graphene-django/commit/f0705e2c25a07024334ea810562d263496ebbd9e





:beers:


