### PR TITLE
Replace dateutils dependency with python-dateutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,10 +233,10 @@ schema = graphene.Schema(
     directives=all_directives
 )
 ```
-**NOTE**: Date directive depends of *dateutils* module, so if you do not have installed it, this directive will not be
-available. You can install *dateutils* module manually:
+**NOTE**: Date directive depends of *dateutil* module, so if you do not have installed it, this directive will not be
+available. You can install *dateutil* module manually:
 ```
-pip install dateutils
+pip install python-dateutil
 ```
 or like this:
 ```

--- a/README.rst
+++ b/README.rst
@@ -253,12 +253,12 @@ you can load like this:
         directives=all_directives
     )
 
-**NOTE**: Date directive depends of *dateutils* module, so if you do not have installed it, this directive will not be
-available. You can install *dateutils* module manually:
+**NOTE**: Date directive depends of *dateutil* module, so if you do not have installed it, this directive will not be
+available. You can install *dateutil* module manually:
 
 .. code:: python
 
-    pip install dateutils
+    pip install python-dateutil
 
 
 or like this:

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     ],
     extras_require={
         'date': [
-            'dateutils>=0.6.6',
+            'python-dateutil>=2.7.3',
         ]
     },
     include_package_data=True,


### PR DESCRIPTION
`dateutils` is listed as a dependency but never used in the project. Instead, imports come from `dateutil`, which maps to the `python-dateutil` name on PyPI. This currently works because `python-dateutil` is a dependency of `dateutils`, but the `extras_require` and documentation should be updated to reflect the correct library being used.