### PR TITLE
Implement default ordering

### DIFF
--- a/graphene_django_extras/paginations/fields.py
+++ b/graphene_django_extras/paginations/fields.py
@@ -61,7 +61,7 @@ class LimitOffsetPaginationField(AbstractPaginationField):
             cutoff=self.max_limit
         )
 
-        order = kwargs.pop(self.ordering_param, None)
+        order = kwargs.pop(self.ordering_param, None) or self.ordering
         if order:
             if ',' in order:
                 order = order.strip(',').replace(' ', '').split(',')
@@ -145,7 +145,7 @@ class PagePaginationField(AbstractPaginationField):
 
         offset = int(count - fabs(page_size * page)) if page < 0 else page_size * (page - 1)
 
-        order = kwargs.pop(self.ordering_param, None)
+        order = kwargs.pop(self.ordering_param, None) or self.ordering
         if order:
             if ',' in order:
                 order = order.strip(',').replace(' ', '').split(',')

--- a/graphene_django_extras/paginations/pagination.py
+++ b/graphene_django_extras/paginations/pagination.py
@@ -87,7 +87,7 @@ class LimitOffsetGraphqlPagination(BaseDjangoGraphqlPagination):
         if limit is None:
             return qs
 
-        order = kwargs.pop(self.ordering_param, None)
+        order = kwargs.pop(self.ordering_param, None) or self.ordering
         if order:
             if ',' in order:
                 order = order.strip(',').replace(' ', '').split(',')
@@ -186,7 +186,7 @@ class PageGraphqlPagination(BaseDjangoGraphqlPagination):
 
         offset = max(0, int(count + page_size * page)) if page < 0 else page_size * (page - 1)
 
-        order = kwargs.pop(self.ordering_param, None)
+        order = kwargs.pop(self.ordering_param, None) or self.ordering
         if order:
             if ',' in order:
                 order = order.strip(',').replace(' ', '').split(',')


### PR DESCRIPTION
Pagination objects take an `ordering` parameter, but it doesn't appear to be used at all. This PR uses it if the GraphQL parameter isn't given or is blank.