### PR TITLE
WIP: Relax dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,10 +55,10 @@ setup(
     packages=get_packages(),
 
     install_requires=[
-        'graphql-core==2.0',
-        'graphene==2.0.1',
-        'graphene-django==2.0',
-        'django-filter==1.1.0',
+        'graphql-core>=2.0',
+        'graphene>=2.0.1',
+        'graphene-django>=2.0',
+        'django-filter>=1.1.0',
         'djangorestframework>=3.6.0'
     ],
     extras_require={

--- a/testproject/urls.py
+++ b/testproject/urls.py
@@ -6,5 +6,9 @@ from graphene_django.views import GraphQLView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('graphql', csrf_exempt(GraphQLView.as_view(graphiql=True))),
+    path(
+        'graphql',
+        csrf_exempt(GraphQLView.as_view(graphiql=True)),
+        name='graphql',
+    ),
 ]


### PR DESCRIPTION
Allow graphene-django-extras to install newer versions of the listed
dependencies. These were previously pinned due to graphene-django's
incompatibility with django-filter 2.0; this is no longer an issue, so
the dependency pinning should no longer be required.

Additionally, provide a `name` parameter to the graphql URL in the test
project to allow Django's `reverse` function to find it correctly.

Note: One test currently fails, but it fails consistently before and
after these changes.