### PR TITLE
Fix the grammar for the field ordering description

### DIFF
--- a/graphene_django_extras/paginations/fields.py
+++ b/graphene_django_extras/paginations/fields.py
@@ -47,7 +47,7 @@ class LimitOffsetPaginationField(AbstractPaginationField):
                                          description='The initial index from which to return the results.')
         
         kwargs[ordering_param] = String(default_value='',
-                                        description='A string or coma separate strings values that indicating the '
+                                        description='A string or comma delimited string values that indicate the '
                                                     'default ordering when obtaining lists of objects.')
 
         super(LimitOffsetPaginationField, self).__init__(List(_type), *args, **kwargs)

--- a/graphene_django_extras/paginations/pagination.py
+++ b/graphene_django_extras/paginations/pagination.py
@@ -72,7 +72,7 @@ class LimitOffsetGraphqlPagination(BaseDjangoGraphqlPagination):
                                                     '\'default_limit\': {}, and \'max_limit\': {}'.format(
                                                         self.default_limit, self.max_limit)),
             self.offset_query_param: Int(description='The initial index from which to return the results. Default: 0'),
-            self.ordering_param: String(description='A string or coma separate strings values that indicating the '
+            self.ordering_param: String(description='A string or comma delimited string values that indicate the '
                                                     'default ordering when obtaining lists of objects.')
         }
 
@@ -130,7 +130,7 @@ class PageGraphqlPagination(BaseDjangoGraphqlPagination):
         # Default ordering value: ""
         self.ordering = ordering
 
-        # A string or coma separate strings values that indicating the default ordering when obtaining lists of objects.
+        # A string or comma delimited string values that indicate the default ordering when obtaining lists of objects.
         # Uses Django order_by syntax
         self.ordering_param = ordering_param
 
@@ -151,7 +151,7 @@ class PageGraphqlPagination(BaseDjangoGraphqlPagination):
         paginator_dict = {
             self.page_query_param: Int(default_value=1,
                                        description='A page number within the result paginated set. Default: 1'),
-            self.ordering_param: String(description='A string or coma separate strings values that indicating the '
+            self.ordering_param: String(description='A string or comma delimited string values that indicate the '
                                                     'default ordering when obtaining lists of objects.')
         }
 


### PR DESCRIPTION
This is a pretty small change. I noticed some blatantly incorrect grammar in my GraphiQL client, so I figured I'd propose a fix.

Please excuse the sloppy commit history, I didn't clone my fork locally. Since they're grammar edits I just used the github interface.