### PR TITLE
Add results_field_name to DjangoSerializerType factory function

### DIFF
--- a/graphene_django_extras/types.py
+++ b/graphene_django_extras/types.py
@@ -362,7 +362,8 @@ class DjangoSerializerType(ObjectType):
             'nested_fields': nested_fields,
             'registry': registry,
             'skip_registry': False,
-            'filterset_class': filterset_class
+            'filterset_class': filterset_class,
+            'results_field_name': results_field_name,
         }
 
         output_type = registry.get_type_for_model(model)


### PR DESCRIPTION
There is currently no way to customize the `results` keyword in graphql collections. This allows the user to customize this return type for `DjangoSerializerTypes` (what we are using this for) by passing `results_field_name` to the factory function. An example implementation:

```
class MyModelType(DjangoSerializerType):

  class Meta:
    description = "Model type definition "
    serializer_class = MyModelSerializer
    pagination = LimitOffsetGraphqlPagination(default_limit=20)
    filterset_class = MyModelFilter
    results_field_name = 'items'
```