### PR TITLE
Count in pagination is so slow

### DIFF
--- a/graphene_django_extras/paginations/pagination.py
+++ b/graphene_django_extras/paginations/pagination.py
@@ -77,7 +77,6 @@ class LimitOffsetGraphqlPagination(BaseDjangoGraphqlPagination):
         }
 
     def paginate_queryset(self, qs, **kwargs):
-        count = _get_count(qs)
         limit = _nonzero_int(
             kwargs.get(self.limit_query_param, None),
             strict=True,
@@ -96,13 +95,7 @@ class LimitOffsetGraphqlPagination(BaseDjangoGraphqlPagination):
             else:
                 qs = qs.order_by(order)
 
-        if limit < 0:
-            offset = kwargs.get(self.offset_query_param, count) + limit
-        else:
-            offset = kwargs.get(self.offset_query_param, 0)
-
-        if count == 0 or offset > count or offset < 0:
-            return []
+        offset = kwargs.get(self.offset_query_param, 0)
 
         return qs[offset:offset + fabs(limit)]
 


### PR DESCRIPTION
I do really complex requests with subrequests, ordering, etc

And I notified that my each requests are launched twice:

As there's a `.count()` in pagination, my complex requests with pagination is launched a 1st time for count, a 2nd time for get the queryset limited.

So I just applied this patch on my side, it:
- Doesn't launch `.count()`
- Doesn't take in consideration when limit < 0 (why it could be)
- Doesn't return an empty list (maybe wrong but it should return an empty qs in facts)

This PR is not done, I wait your comment about:
- Is it accepted
- Should I apply it to the other pagination classes
- Should I do separate pagination classes for this behavior

Thanks