### PR TITLE
Don't require a specific version of django-filter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,15 +49,15 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
-
+    
     keywords='api graphql protocol rest graphene django',
-
+    
     packages=get_packages(),
-
+    
     install_requires=[
-        'graphql-core==2.0',
-        'graphene==2.0.1',
-        'graphene-django==2.0',
+        'graphql-core>=2.1.0',
+        'graphene>=2.1.3',
+        'graphene-django>=2.2.0',
         'django-filter>=1.1.0',
         'djangorestframework>=3.6.0'
     ],


### PR DESCRIPTION
This issue was fixed: https://github.com/graphql-python/graphene-django/pull/492 in September.

We also need to update the version of graphene-django.