### PR TITLE
page pagination: fall back to default page_size when page_size_query_param is missing in query

### DIFF
--- a/graphene_django_extras/paginations/pagination.py
+++ b/graphene_django_extras/paginations/pagination.py
@@ -160,7 +160,7 @@ class PageGraphqlPagination(BaseDjangoGraphqlPagination):
         page = kwargs.pop(self.page_query_param, 1)
         if self.page_size_query_param:
             page_size = _nonzero_int(
-                kwargs.get(self.page_size_query_param, None),
+                kwargs.get(self.page_size_query_param, self.page_size),
                 strict=True,
                 cutoff=self.max_page_size
             )


### PR DESCRIPTION
When page_size_query_param is set in the constructor but a query does not contain the param, fall back to self.page_size also given in the constructor.

It would probably make sense to comment in the ValueError on line 173 because page_size should never be None expect for invalid constructor parameters.