### PR TITLE
Fix:  Update import of ErrorType 

### DIFF
--- a/graphene_django_extras/mutation.py
+++ b/graphene_django_extras/mutation.py
@@ -5,7 +5,7 @@ from graphene import Boolean, List, Field, ID, Argument, ObjectType
 from graphene.types.base import BaseOptions
 from graphene.utils.deprecated import warn_deprecation
 from graphene.utils.props import props
-from graphene_django.rest_framework.types import ErrorType
+from graphene_django.types import ErrorType
 
 from .base_types import factory_type
 from .registry import get_global_registry

--- a/graphene_django_extras/types.py
+++ b/graphene_django_extras/types.py
@@ -10,7 +10,7 @@ from graphene.types.utils import yank_fields_from_attrs
 from graphene.utils.deprecated import warn_deprecation
 from graphene.utils.props import props
 from graphene_django.fields import DjangoListField
-from graphene_django.rest_framework.types import ErrorType
+from graphene_django.types import ErrorType
 from graphene_django.utils import (
     is_valid_django_model,
     DJANGO_FILTER_INSTALLED,


### PR DESCRIPTION
Just a quick fix because of this change to graphene-django:

https://github.com/graphql-python/graphene-django/issues/520