### PR TITLE
Fix unexpected keyword argument 'type' error

### DIFF
--- a/graphene_django_extras/directives/date.py
+++ b/graphene_django_extras/directives/date.py
@@ -235,7 +235,7 @@ class DateGraphQLDirective(BaseExtraGraphQLDirective):
     def get_args():
         return {
             "format": GraphQLArgument(
-                type=GraphQLString, description="A format given by dateutil module"
+                type_=GraphQLString, description="A format given by dateutil module"
             )
         }
 

--- a/graphene_django_extras/directives/list.py
+++ b/graphene_django_extras/directives/list.py
@@ -26,7 +26,7 @@ class SampleGraphQLDirective(BaseExtraGraphQLDirective):
     def get_args():
         return {
             "k": GraphQLArgument(
-                type=GraphQLNonNull(GraphQLInt), description="Value to default to"
+                type_=GraphQLNonNull(GraphQLInt), description="Value to default to"
             )
         }
 

--- a/graphene_django_extras/directives/string.py
+++ b/graphene_django_extras/directives/string.py
@@ -36,7 +36,7 @@ class DefaultGraphQLDirective(BaseExtraGraphQLDirective):
     def get_args():
         return {
             "to": GraphQLArgument(
-                type=GraphQLNonNull(GraphQLString), description="Value to default to"
+                type_=GraphQLNonNull(GraphQLString), description="Value to default to"
             )
         }
 
@@ -56,7 +56,7 @@ class Base64GraphQLDirective(BaseExtraGraphQLDirective):
     def get_args():
         return {
             "op": GraphQLArgument(
-                type=GraphQLString,
+                type_=GraphQLString,
                 description='Action to perform: "encode" or "decode"',
             )
         }
@@ -88,7 +88,7 @@ class NumberGraphQLDirective(BaseExtraGraphQLDirective):
     def get_args():
         return {
             "as": GraphQLArgument(
-                type=GraphQLNonNull(GraphQLString), description="Value to default to"
+                type_=GraphQLNonNull(GraphQLString), description="Value to default to"
             )
         }
 
@@ -103,7 +103,7 @@ class CurrencyGraphQLDirective(BaseExtraGraphQLDirective):
     def get_args():
         return {
             "symbol": GraphQLArgument(
-                type=GraphQLString, description="Currency symbol (default: $)"
+                type_=GraphQLString, description="Currency symbol (default: $)"
             )
         }
 
@@ -206,7 +206,7 @@ class StripGraphQLDirective(BaseExtraGraphQLDirective):
     def get_args():
         return {
             "chars": GraphQLArgument(
-                type=GraphQLString,
+                type_=GraphQLString,
                 description="Value to specify the set of characters to be removed",
             )
         }
@@ -246,11 +246,11 @@ class CenterGraphQLDirective(BaseExtraGraphQLDirective):
     def get_args():
         return {
             "width": GraphQLArgument(
-                type=GraphQLNonNull(GraphQLInt),
+                type_=GraphQLNonNull(GraphQLInt),
                 description="Value to returned str lenght",
             ),
             "fillchar": GraphQLArgument(
-                type=GraphQLString, description="Value to fill the returned str"
+                type_=GraphQLString, description="Value to fill the returned str"
             ),
         }
 
@@ -284,15 +284,15 @@ class ReplaceGraphQLDirective(BaseExtraGraphQLDirective):
     def get_args():
         return {
             "old": GraphQLArgument(
-                type=GraphQLNonNull(GraphQLString),
+                type_=GraphQLNonNull(GraphQLString),
                 description="Value of old character to replace",
             ),
             "new": GraphQLArgument(
-                type=GraphQLNonNull(GraphQLString),
+                type_=GraphQLNonNull(GraphQLString),
                 description="Value of new character to replace",
             ),
             "count": GraphQLArgument(
-                type=GraphQLInt, description="Value to returned str lenght"
+                type_=GraphQLInt, description="Value to returned str lenght"
             ),
         }
 


### PR DESCRIPTION
Ths is not working for my environment that is base on django project.
```
graphene==2.1.8
graphene-django==2.10.0
graphene-django-extras==0.4.8
graphql-core==2.3.2
```

![image](https://user-images.githubusercontent.com/11167117/82638405-cfb87100-9c41-11ea-8eaa-0743da146ae1.png)

after change naming param `type` to `type_` on GraphQLArgument initialization part, it working well!
Thank you Sir :)