### PR TITLE
Fixed bug with model type validation in DjangoObjectType

### DIFF
--- a/graphene_django_extras/types.py
+++ b/graphene_django_extras/types.py
@@ -130,8 +130,7 @@ class DjangoObjectType(ObjectType):
             return True
         if not is_valid_django_model(type(root)):
             raise Exception(('Received incompatible instance "{}".').format(root))
-        model = root._meta.model
-        return model == cls._meta.model
+        return isinstance(root, cls._meta.model)
 
     @classmethod
     def get_node(cls, info, id):


### PR DESCRIPTION
Fixed the bug which was blocked usage inherited classes as the declared graphene type, see example below.

```
class DjangoModel(models.Model):
    name = models.CharField(unique=True)
    uuid = models.UUIDField(primary_key=False, default=uuid.uuid4, editable=False, unique=True)

class MyModel(DjangoModel):
    def some_custom_logic():
        pass

    class Meta:
        proxy = True

class ModelType(DjangoObjectType):
    class Meta:
        model = Model

class MyMutation(graphene.Mutation):
    model = graphene.Field(ModelType, required=False)

    @classmethod
    def mutate(cls, root, info, deployment_id):
        return cls(model=MyModel())
```