### PR TITLE
Made fixes to DateGraphQLDirective.

### DIFF
--- a/graphene_django_extras/directives/date.py
+++ b/graphene_django_extras/directives/date.py
@@ -75,10 +75,10 @@ def _parse(partial_dt):
     """
     dt = None
     try:
+        if isinstance(partial_dt, date):
+            dt = _combine_date_time(partial_dt, time(0, 0, 0))
         if isinstance(partial_dt, datetime):
             dt = partial_dt
-        elif isinstance(partial_dt, date):
-            dt = _combine_date_time(partial_dt, time(0, 0, 0))
         elif isinstance(partial_dt, time):
             dt = _combine_date_time(date.today(), partial_dt)
         elif isinstance(partial_dt, (int, float)):
@@ -250,7 +250,7 @@ class DateGraphQLDirective(BaseExtraGraphQLDirective):
         dt = _parse(value)
         try:
             result = _format_dt(dt, custom_format)
-            if isinstance(value, six.string_types):
+            if isinstance(result, six.string_types):
                 return result or value
             return CustomDateFormat(result or "INVALID FORMAT STRING")
         except ValueError:


### PR DESCRIPTION
`_parse` function was fist checking if `partial_dt` is a datetime object, then if it was date objects. datetime objects will pass both those checks, that's why you need to check it after `isinstance(partial_dt, date)`. This is the reason time was always missing in datetime formatted by that directive.

Also, there mas a mistake in the `resolve` method in the directive. It was checking is the `value` argument is a stings, which is always not true, that's why None was returned. I believe the intention was to check the `result` variable.