### PR TITLE
Fixed update mutation on DjangoSerializerMutation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ mutation{
     }
   }
 
-  userUpdate(newUser:{id:1, username:"John"}){
+  userUpdate(id:1, newUser:{username:"John"}){
     user{
       id
       username


### PR DESCRIPTION
There was no distinction between `create` and `update` operations, thus `update` did not have an ID argument in it.
I made it so `update` takes ID argument not from `input` but from a level higher, just like the `delete` does. Also, now that both `update` and `delete` take it, I could remove the `else` block.