### PR TITLE
NONNULL: Treat DjangoFilterPaginateListField the same as DjangoListField

### DIFF
--- a/graphene_django_extras/fields.py
+++ b/graphene_django_extras/fields.py
@@ -221,7 +221,7 @@ class DjangoFilterPaginateListField(Field):
             kwargs["description"] = "{} list".format(_type._meta.model.__name__)
 
         super(DjangoFilterPaginateListField, self).__init__(
-            List(_type), *args, **kwargs
+            List(NonNull(_type)), *args, **kwargs
         )
 
     @property


### PR DESCRIPTION
Currently DjangoFilterPaginateListField treats list items as nullable whereas DjangoListField doesn't.

This ensures consistent handling of the two.