### PR TITLE
fix results None with PageGraphqlPagination

### DIFF
--- a/graphene_django_extras/paginations/pagination.py
+++ b/graphene_django_extras/paginations/pagination.py
@@ -201,13 +201,12 @@ class PageGraphqlPagination(BaseDjangoGraphqlPagination):
         page = kwargs.pop(self.page_query_param, 1)
         if self.page_size_query_param:
             page_size = _nonzero_int(
-                kwargs.get(self.page_size_query_param, self.page_size),
+                kwargs.get(self.page_size_query_param, self.page_size) or self.page_size,
                 strict=True,
                 cutoff=self.max_page_size,
             )
         else:
             page_size = self.page_size
-
         assert page != 0, ValueError(
             "Page value for PageGraphqlPagination must be a non-zero value"
         )

--- a/tests/queries.py
+++ b/tests/queries.py
@@ -61,3 +61,12 @@ USERS = """query {
   }
 }
 """
+ALL_USERS1_1 = """query {
+  allUsers11 {
+      totalCount
+      results {
+        id
+      }
+  }
+}
+"""

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -12,7 +12,7 @@ from graphene_django_extras.fields import (
     DjangoFilterPaginateListField,
     DjangoFilterListField,
 )
-from graphene_django_extras.paginations import LimitOffsetGraphqlPagination
+from graphene_django_extras.paginations import LimitOffsetGraphqlPagination, PageGraphqlPagination
 from graphene_django_extras.types import (
     DjangoListObjectType,
     DjangoSerializerType,
@@ -43,6 +43,14 @@ class User1ListType(DjangoListObjectType):
             default_limit=25, ordering="-username"
         )
 
+class User2ListType(DjangoListObjectType):
+    class Meta:
+        description = " Type definition for user list "
+        model = User
+        pagination = PageGraphqlPagination(
+            page_size_query_param="page_size",
+            page_size=10
+        )
 
 class UserModelType(DjangoSerializerType):
     class Meta:
@@ -76,6 +84,9 @@ class Query(graphene.ObjectType):
     all_users = DjangoListObjectField(User1ListType, description=_("All Users query"))
     all_users1 = DjangoFilterPaginateListField(
         UserType, pagination=LimitOffsetGraphqlPagination()
+    )
+    all_users1_1 = DjangoListObjectField(
+        User2ListType
     )
     all_users2 = DjangoFilterListField(UserType)
     all_users3 = DjangoListObjectField(

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -158,3 +158,18 @@ class DjangoCustomResolverTest(ParentTest, TestCase):
                 ]
             }
         }
+
+class PageGraphqlPaginationTest(ParentTest, TestCase):
+    query = queries.ALL_USERS1_1
+    expected_return_payload = {
+        "data": {
+            "allUsers11": {
+                "results": [
+                    {
+                        "id":"1"
+                    }
+                ],
+                "totalCount": 1
+            }
+        }
+    }


### PR DESCRIPTION
Backward compatibility with client when using PageGraphqlPagination


Issue:
```
//client
query {
  users {
    totalCount
    results {
      id
    }
  }
}
```

Output:
```
//old version
{
  totalCount: 1,
  users: {
    id: 123
  }
}

//new version (0.5.2)
{
  totalCount: 1,
  users: null
}
```