### PR TITLE
Correction issue #178 : force_text is deprecated

### DIFF
--- a/graphene_django_extras/converter.py
+++ b/graphene_django_extras/converter.py
@@ -9,7 +9,7 @@ from django.contrib.contenttypes.fields import (
     GenericRel,
 )
 from django.db import models
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from graphene import (
     Field,
     ID,
@@ -52,7 +52,7 @@ def assert_valid_name(name):
 
 
 def convert_choice_name(name):
-    name = to_const(force_text(name))
+    name = to_const(force_str(name))
     try:
         assert_valid_name(name)
     except AssertionError:


### PR DESCRIPTION
force_text() is removed in Django 4.0  check https://docs.djangoproject.com/en/dev/releases/4.0/#features-removed-in-4-0